### PR TITLE
Correct translation

### DIFF
--- a/docs/relational-databases/triggers/use-the-inserted-and-deleted-tables.md
+++ b/docs/relational-databases/triggers/use-the-inserted-and-deleted-tables.md
@@ -41,7 +41,7 @@ ms.lasthandoff: 11/09/2017
   
 -   尋找資料修改前後之資料表狀態的差異，並依據這些差異採取動作。  
   
- deleted 資料表會儲存被 DELETE 及 UPDATE 陳述式影響的資料列副本。 在執行 DELETE 或 UPDATE 陳述式時，資料列會從觸發程序資料表刪除，並傳送到 deleted 資料表。 deleted 資料表及其觸發程序資料表兩者通常不會有資料列。  
+ deleted 資料表會儲存被 DELETE 及 UPDATE 陳述式影響的資料列副本。 在執行 DELETE 或 UPDATE 陳述式時，資料列會從觸發程序資料表刪除，並傳送到 deleted 資料表。 deleted 資料表及其觸發程序資料表兩者通常不會有相同的資料列。  
   
  inserted 資料表會儲存被 INSERT 及 UPDATE 陳述式影響的資料列副本。 在插入或更新交易期間，新的資料列會同時加入 inserted 資料表和觸發程序資料表。 inserted 資料表中的資料列即為觸發程序資料表中新資料列的副本。  
   


### PR DESCRIPTION
> The  deleted table and the trigger table ordinarily have no rows in common.

`in common` = `共同的；共有的`