### PR TITLE
update tutorial-sql-editor.md (part1)

### DIFF
--- a/docs/sql-operations-studio/tutorial-sql-editor.md
+++ b/docs/sql-operations-studio/tutorial-sql-editor.md
@@ -37,14 +37,14 @@ ms.lasthandoff: 03/15/2018
 本教學課程需要 SQL Server 或 Azure SQL Database *TutorialDB*。 若要建立 *TutorialDB* 資料庫，請完成下列其中一項快速入門教學：
 
 - [使用 [!INCLUDE[name-sos-short](../includes/name-sos-short.md)] 連接及查詢 SQL Server ](quickstart-sql-server.md)
-- [使 用[!INCLUDE[name-sos-short](../includes/name-sos-short.md)] 連接及查詢 Azure SQL Database ](quickstart-sql-database.md)
+- [使用 [!INCLUDE[name-sos-short](../includes/name-sos-short.md)] 連接及查詢 Azure SQL Database ](quickstart-sql-database.md)
 
 
 ## <a name="quickly-locate-a-database-object-and-perform-a-common-task"></a>快速找出資料庫物件和執行一般工作
 
 [!INCLUDE[name-sos-short](../includes/name-sos-short.md)] 提供的搜尋小工具，以快速找出資料庫物件。 結果清單中提供的內容功能表的一般工作與選取的物件，例如*編輯資料*資料表。
 
-1. 開啟 [伺服器資訊看板] (**Ctrl + G**)，依序展開**資料庫**，然後選取**TutorialDB**。 
+1. 開啟 [伺服器資訊看板] (**Ctrl + G**)，展開**資料庫**，然後選取**TutorialDB**。 
 
 1. 滑鼠右鍵點選 **TutorialDB**，從內容功能表選取**管理**，開啟 *TutorialDB 儀表板*：
 
@@ -57,7 +57,7 @@ ms.lasthandoff: 03/15/2018
 
    ![快速搜尋 widget](./media/tutorial-sql-editor/quick-search-widget.png)
 
-1. 編輯**電子郵件**的第一筆資料，輸入 *orlando0@adventure-works.com*，然後按 **Enter** 鍵儲存變更。
+1. 編輯**電子郵件**欄位的第一筆資料，輸入 *orlando0@adventure-works.com*，然後按 **Enter** 鍵儲存變更。
 
    ![編輯資料](./media/tutorial-sql-editor/edit-data.png)
 

--- a/docs/sql-operations-studio/tutorial-sql-editor.md
+++ b/docs/sql-operations-studio/tutorial-sql-editor.md
@@ -63,7 +63,7 @@ ms.lasthandoff: 03/15/2018
 
 ## <a name="use-t-sql-snippets-to-create-stored-procedures"></a>使用 T-SQL 程式碼片段建立預存程序
 
-SQL Operations Studio 提供許多內建的 T-SQL 程式碼片段，快速建立陳述式。
+SQL Operations Studio 提供許多內建的 T-SQL 程式碼片段，可快速建立陳述式。
 
 
 1. 按下 **Ctrl + N** 開啟新的查詢編輯器。
@@ -77,7 +77,7 @@ SQL Operations Studio 提供許多內建的 T-SQL 程式碼片段，快速建立
    ![程式碼片段](./media/tutorial-sql-editor/snippet.png)
 
 5. 同上一步操作，將所有 *SchemaName* 變更為 *dbo*。 
-6. 程式碼片段包含許多參數預留位置與內容需要更新。 *EXECUTE* 陳述式也包含文字預留位置，因為不知道預存程序有多少參數。 本教學課程更新結果如下列程式碼所示：
+6. 程式碼片段包含許多參數預留位置與內容需要更新。 *EXECUTE* 陳述式也包含文字預留位置，因為不知道預存程序有多少參數。 本教學課程更新程式碼片段後，結果如下列程式碼所示：
 
     ```sql
     -- Create a new stored procedure called 'getCustomer' in schema 'dbo'
@@ -135,7 +135,7 @@ SQL Operations Studio 提供許多內建的 T-SQL 程式碼片段，快速建立
    INSERT INTO dbo.Customers
    ```
 
-5. 滑鼠右鍵點選 **dbo.Customers** 選取 **查看定義**。
+5. 以滑鼠右鍵按一下**dbo.Customers**選取**查看定義**。
 
    ![查看定義](./media/tutorial-sql-editor/peek-definition.png)
 

--- a/docs/sql-operations-studio/tutorial-sql-editor.md
+++ b/docs/sql-operations-studio/tutorial-sql-editor.md
@@ -24,20 +24,20 @@ ms.lasthandoff: 03/15/2018
 
 建立和執行查詢、 預存程序、 指令碼等是資料庫專業人員的核心工作。 本教學課程示範如何在 T-SQL 編輯器來建立資料庫物件中的主要功能。
 
-您可以在本教學課程，了解如何使用[!INCLUDE[name-sos-short](../includes/name-sos-short.md)]至：
+您可以在本教學課程，了解如何使用[!INCLUDE[name-sos-short](../includes/name-sos-short.md)]：
 > [!div class="checklist"]
 > * 搜尋資料庫物件
 > * 編輯資料表資料 
-> * 使用快速撰寫 T-SQL 程式碼片段
-> * 檢視資料庫物件的詳細資料使用*查看定義*和*移至定義*
+> * 使用程式碼片段快速地撰寫 T-SQL 
+> * 使用*查看定義*和*移至定義*檢視資料庫物件的詳細資料
 
 
 ## <a name="prerequisites"></a>必要條件
 
-本教學課程需要 SQL Server 或 Azure SQL Database *TutorialDB*。 若要建立*TutorialDB*資料庫，請完成下列快速入門的其中一個：
+本教學課程需要 SQL Server 或 Azure SQL Database *TutorialDB*。 若要建立 *TutorialDB* 資料庫，請完成下列其中一項快速入門教學：
 
-- [連接及查詢 SQL Server 使用 [!INCLUDE[name-sos-short](../includes/name-sos-short.md)]](quickstart-sql-server.md)
-- [連接及查詢使用 Azure SQL Database [!INCLUDE[name-sos-short](../includes/name-sos-short.md)]](quickstart-sql-database.md)
+- [使用 [!INCLUDE[name-sos-short](../includes/name-sos-short.md)] 連接及查詢 SQL Server ](quickstart-sql-server.md)
+- [使 用[!INCLUDE[name-sos-short](../includes/name-sos-short.md)] 連接及查詢 Azure SQL Database ](quickstart-sql-database.md)
 
 
 ## <a name="quickly-locate-a-database-object-and-perform-a-common-task"></a>快速找出資料庫物件和執行一般工作
@@ -46,38 +46,38 @@ ms.lasthandoff: 03/15/2018
 
 1. 開啟 [伺服器資訊看板] (**Ctrl + G**)，依序展開**資料庫**，然後選取**TutorialDB**。 
 
-1. 開啟*TutorialDB 儀表板*以滑鼠右鍵按一下**TutorialDB** ，然後選取**管理**從內容功能表：
+1. 滑鼠右鍵點選 **TutorialDB**，從內容功能表選取**管理**，開啟 *TutorialDB 儀表板*：
 
    ![操作功能表： 管理](./media/tutorial-sql-editor/insight-open-dashboard.png)
 
-1. 在儀表板，以滑鼠右鍵按一下**dbo。客戶**（在 [搜尋] widget 中) 並選取**編輯資料**。
+1. 在儀表板上，滑鼠右鍵點選 **dbo.Customers**（在 [搜尋] 小工具中) 並選取**編輯資料**。
    
    > [!TIP]
-   > 對於具有許多物件的資料庫，使用 搜尋小工具來快速找出您要尋找的資料表、 檢視等。
+   > 對於包含許多物件的資料庫，您可以透過搜尋小工具快速地找到想要的資料表、檢視表...等。
 
    ![快速搜尋 widget](./media/tutorial-sql-editor/quick-search-widget.png)
 
-1. 編輯**電子郵件**第一個資料列型別中的資料行*orlando0@adventure-works.com*，然後按**Enter**以儲存變更。
+1. 編輯**電子郵件**的第一筆資料，輸入 *orlando0@adventure-works.com*，然後按 **Enter** 鍵儲存變更。
 
    ![編輯資料](./media/tutorial-sql-editor/edit-data.png)
 
-## <a name="use-t-sql-snippets-to-create-stored-procedures"></a>若要建立預存程序使用 T-SQL 程式碼片段
+## <a name="use-t-sql-snippets-to-create-stored-procedures"></a>使用 T-SQL 程式碼片段建立預存程序
 
-SQL 作業 Studio 提供許多內建的 T-SQL 程式碼片段，快速建立陳述式。
+SQL Operations Studio 提供許多內建的 T-SQL 程式碼片段，快速建立陳述式。
 
 
-1. 按下開啟新的查詢編輯器**Ctrl + N**。
+1. 按下 **Ctrl + N** 開啟新的查詢編輯器。
 
-2. 型別**sql**在編輯器中，向下箭號**sqlCreateStoredProcedure**，然後按 *索引標籤*索引鍵 (或*Enter*) 載入儲存的建立程序程式碼片段。
+2. 在編輯器中輸入 **sql**，按向下鍵至 **sqlCreateStoredProcedure**，然後按 *Tab*鍵 (或*Enter*) 載入新增預存程序程式碼片段。
 
    ![snippet-list](./media/tutorial-sql-editor/snippet-list.png)
 
-3. 建立預存程序程式碼片段有兩個欄位設定為 [快速編輯]， *StoredProcedureName*和*SchemaName*。 選取*StoredProcedureName*，按一下滑鼠右鍵，然後選取**變更所有相符項目**。 現在，鍵入*getCustomer* 」 和 「 全部*StoredProcedureName*項目變更為*getCustomer*。
+3. 建立預存程序程式碼片段有兩個欄位可以進行 [快速編輯]， *StoredProcedureName* 和 *SchemaName*。 選取 *StoredProcedureName* ，按一下滑鼠右鍵，然後選取**變更所有相符項目**。 鍵入 *getCustomer* 並將全部 *StoredProcedureName* 項目變更為 *getCustomer*。
 
    ![程式碼片段](./media/tutorial-sql-editor/snippet.png)
 
-5. 將所有*SchemaName*至*dbo*。 
-6. 程式碼片段包含預留位置參數，以及需要更新的本文文字。 *EXECUTE*陳述式也包含預留位置文字，因為它不知道會有程序的參數數目。 如需本教學課程更新程式碼片段結果看起來類似下列程式碼：
+5. 同上一步操作，將所有 *SchemaName* 變更為 *dbo*。 
+6. 程式碼片段包含許多參數預留位置與內容需要更新。 *EXECUTE* 陳述式也包含文字預留位置，因為不知道預存程序有多少參數。 本教學課程更新結果如下列程式碼所示：
 
     ```sql
     -- Create a new stored procedure called 'getCustomer' in schema 'dbo'
@@ -110,36 +110,36 @@ SQL 作業 Studio 提供許多內建的 T-SQL 程式碼片段，快速建立陳�
     GO
     ```
     
-5. 若要建立預存程序，並為它提供的測試回合，請按**F5**。
+5. 若要建立預存程序並測試執行，請按**F5**鍵。
 
-現在建立預存程序，而**結果**窗格會顯示傳回的客戶在 JSON 中。 若要查看格式的 JSON，請按一下傳回的記錄。 
+預存程序現在已經建立，而**結果**窗格會顯示所回傳客戶資料(JSON 格式)。 若要查看已排版的 JSON ，請點選回傳資料。 
 
 
 ## <a name="use-peek-definition"></a>使用查看定義 
 
-SQL 作業 Studio 提供的檢視使用查看定義功能的物件定義的能力。 本節會建立第二個預存程序，並查看有哪些資料行資料表，以快速建立預存程序的主體中使用查看定義。
+透過查看定義功能，SQL Operations Studio 提供檢視物件定義的能力。 本節會建立第二個預存程序，並使用查看定義查看資料表內有那些欄位，快速地建立預存程序主體。
 
-1. 按下開啟新的編輯器**Ctrl + N**。 
+1. 按下 **Ctrl + N** 開啟新的編輯器。 
 
-2. 型別*sql*在編輯器中，向下箭號*sqlCreateStoredProcedure*，然後按 *索引標籤*索引鍵 (或*Enter*) 載入儲存的建立程序程式碼片段。
-3. 在中輸入*setCustomer*如*StoredProcedureName*和*dbo*如*SchemaName*
+2. 在編輯器中輸入 **sql**，按向下鍵至 **sqlCreateStoredProcedure**，然後按 *Tab*鍵 (或*Enter*) 載入新增預存程序程式碼片段。
+3. 在編輯器中輸入 *setCustomer* 取代 *StoredProcedureName*、輸入 *dbo* 取代 *SchemaName*
 
-3. 取代@param具有下列的參數定義的預留位置：
+3. 取代預設參數 @param 為下列的參數定義
 
    ```sql
    @json_val nvarchar(max)
    ```
 
-4. 預存程序的主體取代為下列程式碼：
+4. 取代預存程序的主體為下列程式碼：
    ```sql
    INSERT INTO dbo.Customers
    ```
 
-5. 以滑鼠右鍵按一下**dbo.Customers**選取**查看定義**。
+5. 滑鼠右鍵點選 **dbo.Customers** 選取 **查看定義**。
 
    ![查看定義](./media/tutorial-sql-editor/peek-definition.png)
 
-6. 資料表定義會出現，讓您可以快速查看資料行是資料表中。 參考資料行清單，以輕鬆地完成您的預存程序的陳述式。 完成建立您先前加入至完成的預存程序中，主體並關閉 [查看定義] 視窗的 INSERT 陳述式：
+6. 資料表定義會出現，讓您可以快速查看資料表中的資料欄位。 參考資料欄位清單，輕鬆地完成您的預存程序的陳述式。 完成您先前所建立預存程序主體內的 Insert 陳述式，然後關閉 [查看定義] 視窗：
 
    ```sql
    INSERT INTO dbo.Customers (CustomerId, Name, Location, Email)
@@ -151,8 +151,8 @@ SQL 作業 Studio 提供的檢視使用查看定義功能的物件定義的能�
                Email nvarchar(50)
     )
    ```
-7. 刪除 （或註解化） *EXECUTE*底部的查詢命令。
-8. 是整個陳述式看起來應該類似下列程式碼：
+7. 刪除 （或註解）查詢底下的 *EXECUTE* 命令。
+8. 整個陳述式應該如下列程式碼所示：
 
    ```sql
    -- Create a new stored procedure called 'setCustomer' in schema 'dbo'
@@ -181,7 +181,7 @@ SQL 作業 Studio 提供的檢視使用查看定義功能的物件定義的能�
    GO
    ```
 
-8. 若要建立*setCustomer*預存程序，請按**F5**。
+8. 若要建立 *setCustomer* 預存程序，請按**F5**鍵。
 
 ## <a name="use-save-query-results-as-json-to-test-the-setcustomer-stored-procedure"></a>使用將查詢結果儲存為 JSON，將測試 setCustomer 預存程序
 


### PR DESCRIPTION
1. '至' is redundancy
2. 'Use snippets to quickly write T-SQL' should be '使用/透過程式碼片段快速地撰寫 T-SQL'
3. 'View database object details using Peek Definition and Go to Definition' should be '使用/透過查看定義和移至定義檢視資料庫物件的詳細資料'
4. please use 'SQL Operations Studio' instead of 'SQL 作業 Studio'
5. 'dbo.客戶' is a db table, please don't translation
6. When 'Type' is Verb, Use '輸入' instead of '型別'
7. 註解化 -> 註解
8. After following the tutorial and do it myself, 
8-1 please use ''按下 Ctrl + N 開啟新的查詢編輯器' instead of '按下開啟新的查詢編輯器Ctrl + N' 
8-2 '將所有SchemaName至dbo' and '在中輸入setCustomer如StoredProcedureName和dbo如SchemaName' confuses readers.
...