### PR TITLE
sql operations studio: extension.md suggestion

### DIFF
--- a/docs/sql-operations-studio/extensions.md
+++ b/docs/sql-operations-studio/extensions.md
@@ -22,9 +22,9 @@ ms.lasthandoff: 04/26/2018
 ---
 # <a name="extend-the-functionality-of-includename-sosincludesname-sos-shortmd"></a>擴充功能 [!INCLUDE[name-sos](../includes/name-sos-short.md)]
 
-[!INCLUDE[name-sos](../includes/name-sos-short.md)] 擴充模組提供一個簡單的方式，可以新增更多功能至基礎 [!INCLUDE[name-sos](../includes/name-sos-short.md)] 安裝。。 
+[!INCLUDE[name-sos](../includes/name-sos-short.md)] 擴充模組提供一個簡單的方式，可以新增更多功能至基礎 [!INCLUDE[name-sos](../includes/name-sos-short.md)] 安裝。
 
-擴充功能由 SQL Operations Studio 團隊 (Microsoft) 以及第 3 方社群（您 ！）提供。 如需有關建立擴充功能的詳細資訊，請參閱[開始使用擴充性](https://github.com/Microsoft/sqlopsstudio/wiki/Getting-started-with-Extensibility)。
+擴充功能由 SQL Operations Studio 團隊 (Microsoft) 以及第 3 方社 (您 ！) 提供。 如需有關建立擴充功能的詳細資訊，請參閱[開始使用擴充性](https://github.com/Microsoft/sqlopsstudio/wiki/Getting-started-with-Extensibility)。
 
 
 ## <a name="add-sql-operations-studio-extensions"></a>加入 SQL Operations Studio 擴充功能
@@ -35,7 +35,7 @@ ms.lasthandoff: 04/26/2018
    ![擴充管理員](media/extensions/extension-manager.png)
 
 1. 選取您想要的擴充功能和**安裝**它。
-2. 選取**重新載入**啟用該擴充功能 （只有第一次安裝擴充功能時需要）。
+2. 選取**重新載入**以啟用該擴充功能 (只有第一次安裝擴充功能時需要)。
 1. 透過滑鼠右鍵點選伺服器或資料庫並點選**管理**，瀏覽您的管理儀表板。
 2. 已安裝的擴充功能會以索引標籤方式顯示在您的管理儀表板上：
 

--- a/docs/sql-operations-studio/extensions.md
+++ b/docs/sql-operations-studio/extensions.md
@@ -1,6 +1,6 @@
 ---
-title: 擴充功能的 SQL 作業 Studio （預覽） |Microsoft 文件
-description: 擴充功能加入 SQL 作業 Studio （預覽）
+title: SQL 作業 Studio （預覽）的擴充功能  |Microsoft 文件
+description: 加入擴充功能至 SQL 作業 Studio （預覽）
 ms.custom: tools|sos
 ms.date: 03/28/2018
 ms.reviewer: alayu; erickang; sstein
@@ -22,22 +22,22 @@ ms.lasthandoff: 04/26/2018
 ---
 # <a name="extend-the-functionality-of-includename-sosincludesname-sos-shortmd"></a>擴充功能 [!INCLUDE[name-sos](../includes/name-sos-short.md)]
 
-中的延伸模組[!INCLUDE[name-sos](../includes/name-sos-short.md)]提供一個簡單的方式，將更多的功能新增至基底[!INCLUDE[name-sos](../includes/name-sos-short.md)]安裝。 
+[!INCLUDE[name-sos](../includes/name-sos-short.md)] 擴充模組提供一個簡單的方式，可以新增更多功能至基礎 [!INCLUDE[name-sos](../includes/name-sos-short.md)] 安裝。。 
 
-SQL 作業 Studio team (Microsoft)，會提供擴充功能，以及第 3 個合作對象社群 （您 ！）。 如需有關建立擴充功能的詳細資訊，請參閱[開始使用擴充性](https://github.com/Microsoft/sqlopsstudio/wiki/Getting-started-with-Extensibility)。
+擴充功能由 SQL Operations Studio 團隊 (Microsoft) 以及第 3 方社群（您 ！）提供。 如需有關建立擴充功能的詳細資訊，請參閱[開始使用擴充性](https://github.com/Microsoft/sqlopsstudio/wiki/Getting-started-with-Extensibility)。
 
 
-## <a name="add-sql-operations-studio-extensions"></a>加入 SQL 作業 Studio 擴充功能
-
-1. 若要開啟擴充管理員及存取可用的擴充功能，選取 [擴充功能] 圖示，或選取**延伸**中**檢視**功能表。
+## <a name="add-sql-operations-studio-extensions"></a>加入 SQL Operations Studio 擴充功能
+   
+1. 若要開啟擴充管理員及存取可用的擴充功能，選取 [擴充功能] 圖示，或選取**檢視**功能表中的**擴充功能**。
 2. 選取可用的擴充功能以檢視其詳細資料。
 
    ![擴充管理員](media/extensions/extension-manager.png)
 
 1. 選取您想要的擴充功能和**安裝**它。
-2. 選取**重新載入**啟用該擴充功能 （只需要第一次安裝擴充功能）。
-1. 瀏覽至儀表板管理您的伺服器或資料庫上按一下滑鼠右鍵，然後選取**管理**。
-2. 安裝的擴充功能會顯示為您管理儀表板上的索引標籤：
+2. 選取**重新載入**啟用該擴充功能 （只有第一次安裝擴充功能時需要）。
+1. 透過滑鼠右鍵點選伺服器或資料庫並點選**管理**，瀏覽您的管理儀表板。
+2. 已安裝的擴充功能會以索引標籤方式顯示在您的管理儀表板上：
 
    ![擴充管理員](media/extensions/dashboard-extensions.png)
 


### PR DESCRIPTION
'A of B' in Chinese translation is 'B 的 A', so 'Extend the functionality of SQL Operations Studio (preview)' should be 'SQL 作業 Studio （預覽）擴充功能'
base SQL Operations Studio (preview) installation -> 以 SQL Operations Studio (preview) 安裝程序為基礎
'或選取延伸中檢視功能表' is not correct.
'瀏覽至儀表板管理您的伺服器或資料庫上按一下滑鼠右鍵' is confusing.